### PR TITLE
Implement passing of parent working directory to child prompto

### DIFF
--- a/cmd/prompto/main.go
+++ b/cmd/prompto/main.go
@@ -178,6 +178,17 @@ func get(cmd *cobra.Command, args []string) error {
 					c.Dir = repo
 					c.Stdout = os.Stdout
 					c.Stderr = os.Stderr
+
+					// Get the current working directory
+					currentDir, err := os.Getwd()
+					if err != nil {
+						// Handle error
+						return err
+					}
+
+					// Set the PROMPTO_PARENT_PWD environment variable to the current directory
+					c.Env = append(os.Environ(), "PROMPTO_PARENT_PWD="+currentDir)
+
 					return c.Run()
 				case TemplateCommand:
 					// The file is a glazed TemplateCommand, execute it by passing the arguments

--- a/prompto/git-diff.sh
+++ b/prompto/git-diff.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 # Default values
 branch="origin/main"
 exclude_files=()
@@ -69,7 +71,9 @@ fi
 # Construct the exclusion patterns
 exclude_patterns=""
 for file in "${exclude_files[@]}"; do
-  exclude_patterns+=" :!$file"
+#  exclude_patterns+=" :!$file"
+  # while we're printing, add quotes
+  exclude_patterns+=" ':!$file'"
 done
 
 # Construct the inclusion patterns
@@ -81,5 +85,7 @@ if [ -n "$include_paths" ]; then
   done
 fi
 
+pwd
 # Run git diff command
-git diff "$context_size" "$branch" -- . $exclude_patterns $include_patterns
+echo cd "$PROMPTO_PARENT_PWD"
+cd "$PROMPTO_PARENT_PWD" && pwd && git diff "$context_size" "$branch" -- . $exclude_patterns $include_patterns

--- a/prompto/git-diff.sh
+++ b/prompto/git-diff.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 # Default values
 branch="origin/main"
 exclude_files=()


### PR DESCRIPTION
This pull request introduces changes that allow the parent working directory to be passed to the child prompto. This is achieved by setting the `PROMPTO_PARENT_PWD` environment variable to the current directory. 

Key changes include:

- In `cmd/prompto/main.go`, we retrieve the current working directory and set it as an environment variable for the child process.
- In `prompto/git-diff.sh`, we use the `PROMPTO_PARENT_PWD` environment variable to change the directory before running the git diff command.

