### PR TITLE
Add prompt statistics when copying to clipboard

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
+	github.com/weaviate/tiktoken-go v0.0.2
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 toolchain go1.23.3
 
 require (
+	github.com/a-h/templ v0.2.793
 	github.com/charmbracelet/huh v0.6.0
 	github.com/go-go-golems/clay v0.1.17
 	github.com/go-go-golems/glazed v0.5.18
@@ -19,7 +20,6 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
-	github.com/a-h/templ v0.2.793 // indirect
 	github.com/adrg/frontmatter v0.2.0 // indirect
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,8 @@ github.com/tj/assert v0.0.0-20190920132354-ee03d75cd160 h1:NSWpaDaurcAJY7PkL8Xt0
 github.com/tj/assert v0.0.0-20190920132354-ee03d75cd160/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/go-naturaldate v1.3.0 h1:OgJIPkR/Jk4bFMBLbxZ8w+QUxwjqSvzd9x+yXocY4RI=
 github.com/tj/go-naturaldate v1.3.0/go.mod h1:rpUbjivDKiS1BlfMGc2qUKNZ/yxgthOfmytQs8d8hKk=
+github.com/weaviate/tiktoken-go v0.0.2 h1:lkwTMEoXSFSXxYvw1c44/xz3OOAh27L3+3vvNN/TSSg=
+github.com/weaviate/tiktoken-go v0.0.2/go.mod h1:u47qSckEGSi4sOcVJmUnd3xoHpDV9/5FDDi3KUCFUq4=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/yuin/goldmark v1.7.1/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=

--- a/pkg/server/static/js/favorites.js
+++ b/pkg/server/static/js/favorites.js
@@ -10,11 +10,22 @@ function getFavorites() {
 }
 
 function copyToClipboard(text) {
-    fetch("/prompts/" + text)
-        .then(response => response.text())
-        .then(content => {
-            navigator.clipboard.writeText(content).then(() => {
+    fetch("/prompts/" + text, {
+        headers: {
+            'Accept': 'application/json'
+        }
+    })
+        .then(response => response.json())
+        .then(data => {
+            navigator.clipboard.writeText(data.content).then(() => {
                 const toastEl = document.getElementById('copyToast');
+                const toastBody = toastEl.querySelector('.toast-body');
+                toastBody.innerHTML = `
+                    <i class="bi bi-clipboard-check me-2"></i>Copied to clipboard!<br>
+                    <small class="text-white-50">
+                        ${data.stats.tokens} tokens • ${data.stats.lines} lines • ${data.stats.size} bytes
+                    </small>
+                `;
                 const toast = new bootstrap.Toast(toastEl);
                 toast.show();
             });


### PR DESCRIPTION
Adds token count, line count, and size statistics when copying prompts:

* Add JSON endpoint for prompt content with metadata and statistics
* Use tiktoken to count tokens with cl100k_base encoding
* Display stats in toast notification after copying
